### PR TITLE
Fix node v0.12+ error if res.setHeader value is undefined

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,7 +92,9 @@ function start(opts) {
     http.createServer(function(req, res) {
         // CORS headers, allow everything
         res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader("Access-Control-Allow-Headers", req.headers["Access-Control-Request-Headers"]);
+        if (req.headers["Access-Control-Request-Headers"]) {
+            res.setHeader("Access-Control-Allow-Headers", req.headers["Access-Control-Request-Headers"]);
+        }
         if (req.method === 'POST') {
             handlePost(req, res);
         } else {


### PR DESCRIPTION
Fixes `Error: `value` required in setHeader("Access-Control-Allow-Headers", value)`.
Similar to [http://stackoverflow.com/questions/29152462/node-js-0-12-and-grunt-contrib-connect-error-calling-setheader#answer-29152463](http://stackoverflow.com/questions/29152462/node-js-0-12-and-grunt-contrib-connect-error-calling-setheader#answer-29152463)
